### PR TITLE
prevents throwing an error if no matching elements are found.

### DIFF
--- a/js/daterangepicker.jQuery.js
+++ b/js/daterangepicker.jQuery.js
@@ -107,9 +107,11 @@ jQuery.fn.daterangepicker = function(settings){
 		if(inputDateBtemp == null){inputDateBtemp = inputDateAtemp;} 
 	}
 	else {
-		inputDateAtemp = Date.parse( rangeInput.val().split(options.rangeSplitter)[0] );
-		inputDateBtemp = Date.parse( rangeInput.val().split(options.rangeSplitter)[1] );
-		if(inputDateBtemp == null){inputDateBtemp = inputDateAtemp;} //if one date, set both
+		if(rangeInput.val()){
+			inputDateAtemp = Date.parse( rangeInput.val().split(options.rangeSplitter)[0] );
+			inputDateBtemp = Date.parse( rangeInput.val().split(options.rangeSplitter)[1] );
+			if(inputDateBtemp == null){inputDateBtemp = inputDateAtemp;} //if one date, set both
+		}
 	}
 	if(inputDateAtemp != null){inputDateA = inputDateAtemp;}
 	if(inputDateBtemp != null){inputDateB = inputDateBtemp;}


### PR DESCRIPTION
i use a generic $('.daterangepicker').daterangepicker(); throughout my entire site.  for pages that dont have a .datepicker element, it was throwing an error.  this change does a check for rangeInput.val() before it tries to extract the dates.