### PR TITLE
Fix for IE7 and IE8

### DIFF
--- a/js/daterangepicker.jQuery.js
+++ b/js/daterangepicker.jQuery.js
@@ -120,7 +120,7 @@ jQuery.fn.daterangepicker = function(settings){
 	var rpPresets = (function(){
 		var ul = jQuery('<ul class="ui-widget-content"></ul>').appendTo(rp);
 		jQuery.each(options.presetRanges,function(){
-			jQuery('<li class="ui-daterangepicker-'+ this.text.replace(/ /g, '') +' ui-corner-all"><a href="#">'+ this.text +'</a></li>')
+			jQuery('<li class="ui-daterangepicker-'+ $(this).text().replace('/\u0020/g', '')+' ui-corner-all"><a href="#">'+ this.text +'</a></li>')
 			.data('dateStart', this.dateStart)
 			.data('dateEnd', this.dateEnd)
 			.appendTo(ul);


### PR DESCRIPTION
Restrict the scope of this so that IE can resolve the correct object.
Update the .replace() string to a non-breaking space wrapped in single quotes to resolve IE treating {/ /g} as {//g}.
