### PR TITLE
Quick fix for jQuery 1.8 for outerHeight 

### DIFF
--- a/js/daterangepicker.jQuery.js
+++ b/js/daterangepicker.jQuery.js
@@ -211,7 +211,7 @@
 				side = 'right', val =  offRight;
 			}
 
-			rp.parent().css(side, val).css('top', riOffset.top + relEl.outerHeight());
+			rp.parent().css(side, val).css('top', riOffset.top + relEl.outerHeight(true));
 		}
 
 


### PR DESCRIPTION
Just adds boolean parameter to outerHeight for jQuery 1.8+.   Returns an object otherwise.