### PR TITLE
Allow callbacks to do non-date things

### DIFF
--- a/js/daterangepicker.jQuery.js
+++ b/js/daterangepicker.jQuery.js
@@ -264,8 +264,10 @@
 				});
 				var dateStart = (typeof el.data('dateStart') == 'string') ? Date.parse(el.data('dateStart')) : el.data('dateStart')();
 				var dateEnd = (typeof el.data('dateEnd') == 'string') ? Date.parse(el.data('dateEnd')) : el.data('dateEnd')();
-				rp.find('.range-start').datepicker('setDate', dateStart).find('.ui-datepicker-current-day').trigger('click');
-				rp.find('.range-end').datepicker('setDate', dateEnd).find('.ui-datepicker-current-day').trigger('click');
+				if (dateStart)
+					rp.find('.range-start').datepicker('setDate', dateStart).find('.ui-datepicker-current-day').trigger('click');
+				if (dateEnd)
+					p.find('.range-end').datepicker('setDate', dateEnd).find('.ui-datepicker-current-day').trigger('click');
 			}
 
 			return false;


### PR DESCRIPTION
if dateStart and/or dateEnd are callbacks that return false, don't try to set the field, assume the callback already did it.  Useful for setting field to non-date values.
